### PR TITLE
Add instructions in case of "notebook" renderer failure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Depending on your programming environment, you may need to specify a particular 
 
 - If you are using __JupyterLab__, __Google Colab__, or __nteract__ you should not need to do anything &mdash; the correct renderer will be enabled by default.
 - If you are using __Jupyter Notebook__, you need to enable the notebook renderer by invoking the following code:
-  `alt.renderers.enable('notebook')`
+  `alt.renderers.enable('notebook')`. If this command fails with a `Value Error: to use the 'notebook' renderer...`, you may need to revert to an older version of vega (the current release v2.0.* is for the upcoming Altair v3.0): `conda install -c conda-forge vega=1.3` or `pip install vega==1.3` (full context [here](https://github.com/altair-viz/altair/issues/1114)).
 
 ## Credits
 

--- a/altair_introduction.ipynb
+++ b/altair_introduction.ipynb
@@ -55,7 +55,7 @@
     "Depending on your programming environment, you may need to specify a particular [renderer](https://altair-viz.github.io/user_guide/renderers.html) for Altair.\n",
     "\n",
     "* If you are using __JupyterLab__, __Google Colab__, or __nteract__ you should not need to do anything (the correct renderer will be enabled by default).\n",
-    "* If you are using __Jupyter Notebook__, you need to enable the notebook renderer:\n"
+    "* If you are using __Jupyter Notebook__, you need to enable the notebook renderer (below). If this command fails with a \"`Value Error: to use the 'notebook' renderer...`\", you may need to revert to an older version of vega (the current release v2.0.* is for the upcoming Altair v3.0): \"`conda install -c conda-forge vega=1.3`\" or \"`pip install vega==1.3`\" (full context [here](https://github.com/altair-viz/altair/issues/1114)).\n"
    ]
   },
   {
@@ -33936,7 +33936,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
If `vega@2.*` is installed, setting the 'notebook' renderer in Altair will fail (should be fixed in upcoming Altair 3 release). Add instructions for dealing with this case.