### PR TITLE
replace rangeStep with `chart.properties(width={"step": rangeStep})`

### DIFF
--- a/altair_introduction.ipynb
+++ b/altair_introduction.ipynb
@@ -33649,7 +33649,7 @@
     "    brush     # add interval brush selection to the chart\n",
     ").properties(\n",
     "    height=50, # set the default chart height to 50 pixels\n",
-    "    width=400\n",
+    "    width=400 # set the default chart width to 400 pixels\n",
     ")\n",
     "\n",
     "# a detail scatterplot of horsepower vs. mileage\n",
@@ -33659,7 +33659,7 @@
     "    alt.Y('Miles_per_Gallon'),\n",
     "    # set opacity based on brush selection\n",
     "    opacity=opacity\n",
-    ").properties(width=400)\n",
+    ").properties(width=400) # set the second chart's width to match the width of the first chart\n",
     "\n",
     "# vertically concatenate (vconcat) charts using the '&' operator\n",
     "overview & detail"

--- a/altair_introduction.ipynb
+++ b/altair_introduction.ipynb
@@ -33641,7 +33641,6 @@
     "# add the interval brush to select cars over time\n",
     "overview = alt.Chart(cars).mark_bar().encode(\n",
     "    alt.X('Year:O', timeUnit='year',   # extract year unit, treat as ordinal\n",
-    "      scale=alt.Scale(rangeStep=None), # subbdivide the full default chart width\n",
     "      axis=alt.Axis(title=None, labelAngle=0) # no title, no label angle\n",
     "    ),\n",
     "    alt.Y('count()', title=None), # counts, no axis title\n",

--- a/altair_introduction.ipynb
+++ b/altair_introduction.ipynb
@@ -33648,7 +33648,8 @@
     ").add_selection(\n",
     "    brush     # add interval brush selection to the chart\n",
     ").properties(\n",
-    "    height=50 # set the default chart height to 50 pixels\n",
+    "    height=50, # set the default chart height to 50 pixels\n",
+    "    width=400\n",
     ")\n",
     "\n",
     "# a detail scatterplot of horsepower vs. mileage\n",
@@ -33658,7 +33659,7 @@
     "    alt.Y('Miles_per_Gallon'),\n",
     "    # set opacity based on brush selection\n",
     "    opacity=opacity\n",
-    ")\n",
+    ").properties(width=400)\n",
     "\n",
     "# vertically concatenate (vconcat) charts using the '&' operator\n",
     "overview & detail"

--- a/altair_marks_encoding.ipynb
+++ b/altair_marks_encoding.ipynb
@@ -18855,7 +18855,7 @@
     "id": "rHX8bKgbzW3I"
    },
    "source": [
-    "The bar width is set to a default size. To change the width, _try setting the \\`rangeStep\\` property of the \\`x\\` channel's \\`scale\\` attribute_. (In a later module we will take a closer look at configuring axes, scales, and legends.)\n",
+    "The bar width is set to a default size. We will discuss how to adjust this width later on in this excercise. (In a later module we will take a closer look at configuring axes, scales, and legends.)\n",
     "\n",
     "Bars can also be stacked. Let's change the `x` encoding to use the `cluster` field, and encode `country` using the `color` channel. We'll also disable the legend (which would be very long with colors for all countries!) and use tooltips for the country name."
    ]
@@ -31335,7 +31335,7 @@
     "\n",
     "Below let's create a slope graph comparing the populations of each country at minimum and maximum years in our full dataset: 1955 and 2005. We first create a new Pandas data frame filtered to those years, then use Altair to create the slope graph.\n",
     "\n",
-    "By default, Altair places the years close together. To better space out the years along the x-axis, we can use the `scale` parameter's `rangeStep` property to indicate the size (in pixels) of discrete steps along the x-axis range. Try adjusting the `rangeStep` below and see how the chart changes in response."
+    "By default, Altair places the years close together. To better space out the years along the x-axis, we can indicate the size (in pixels) of discrete steps along the width of our chart as indicated by the comment below. Try adjusting the `step` value below and see how the chart changes in response."
    ]
   },
   {
@@ -32424,10 +32424,12 @@
     "dataTime = data.loc[(data['year'] == 1955) | (data['year'] == 2005)]\n",
     "\n",
     "alt.Chart(dataTime).mark_line(opacity=0.5).encode(\n",
-    "    alt.X('year:O', scale=alt.Scale(rangeStep=50)),\n",
+    "    alt.X('year:O'),\n",
     "    alt.Y('pop:Q'),\n",
     "    alt.Color('country:N', legend=None),\n",
     "    alt.Tooltip('country:N')\n",
+    ").properties(\n",
+    "    width={\"step\": 50} #adjust this parameter\n",
     ")"
    ]
   },
@@ -34172,9 +34174,11 @@
    ],
    "source": [
     "alt.Chart(dataNA).mark_area().encode(\n",
-    "    alt.X('year:O', scale=alt.Scale(rangeStep=40)),\n",
+    "    alt.X('year:O'),\n",
     "    alt.Y('min(fertility):Q'),\n",
     "    alt.Y2('max(fertility):Q')\n",
+    ").properties(\n",
+    "    width={\"step\": 40}\n",
     ")"
    ]
   },
@@ -34531,9 +34535,11 @@
    ],
    "source": [
     "alt.Chart(dataNA).mark_area().encode(\n",
-    "    alt.Y('year:O', scale=alt.Scale(rangeStep=40)),\n",
+    "    alt.Y('year:O'),\n",
     "    alt.X('min(fertility):Q'),\n",
     "    alt.X2('max(fertility):Q')\n",
+    ").properties(\n",
+    "    width={\"step\": 40}\n",
     ")"
    ]
   },
@@ -34588,7 +34594,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/altair_marks_encoding.ipynb
+++ b/altair_marks_encoding.ipynb
@@ -34594,7 +34594,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Per the [latest release notes](https://github.com/altair-viz/altair/releases) 

![image](https://user-images.githubusercontent.com/1483922/72196602-3beeb280-33ce-11ea-88aa-9aee08e576ca.png)

The current use of `rangeStep` is causing an error for people trying to run this notebook with the latest version of Altair.   I tried to make the most minimal change possible to the notebook so that the diffs are human-readable.  🙇 Thank you so much for this very useful tutorial.

cc/: @dansbecker