### PR TITLE
field annotation syntax example; curriculum link

### DIFF
--- a/altair_introduction.ipynb
+++ b/altair_introduction.ipynb
@@ -971,7 +971,7 @@
     "- `'b:Q'` indicates a *quantitative* type (numerical data with meaningful magnitudes), and\n",
     "- `'b:T'` indicates a *temporal* type (date/time data)\n",
     "\n",
-    "For example, `alt.X('precip:N')`\n",
+    "For example, `alt.X('precip:N')`.\n",
     "\n",
     "Explicit annotation of data types is necessary when data is loaded from an external URL directly by Vega-Lite (skipping Pandas entirely), or when we wish to use a type that differs from the type that was automatically inferred.\n",
     "\n",

--- a/altair_introduction.ipynb
+++ b/altair_introduction.ipynb
@@ -971,7 +971,7 @@
     "- `'b:Q'` indicates a *quantitative* type (numerical data with meaningful magnitudes), and\n",
     "- `'b:T'` indicates a *temporal* type (date/time data)\n",
     "\n",
-    "For example, `alt.X('precip:N')`",
+    "For example, `alt.X('precip:N')`\n",
     "\n",
     "Explicit annotation of data types is necessary when data is loaded from an external URL directly by Vega-Lite (skipping Pandas entirely), or when we wish to use a type that differs from the type that was automatically inferred.\n",
     "\n",

--- a/altair_introduction.ipynb
+++ b/altair_introduction.ipynb
@@ -971,11 +971,13 @@
     "- `'b:Q'` indicates a *quantitative* type (numerical data with meaningful magnitudes), and\n",
     "- `'b:T'` indicates a *temporal* type (date/time data)\n",
     "\n",
+    "For example, `alt.X('precip:N')`",
+    "\n",
     "Explicit annotation of data types is necessary when data is loaded from an external URL directly by Vega-Lite (skipping Pandas entirely), or when we wish to use a type that differs from the type that was automatically inferred.\n",
     "\n",
     "What do you think will happen to our chart above if we treat `precip` as a nominal or ordinal variable, rather than a quantitative variable? _Modify the code above and find out!_\n",
     "\n",
-    "We will take a closer look at data types and encoding channels in the next notebook."
+    "We will take a closer look at data types and encoding channels in the next notebook of the [data visualization curriculum](https://github.com/uwdata/visualization-curriculum#data-visualization-curriculum)."
    ]
   },
   {


### PR DESCRIPTION
Added an example to clarify the `b:N` field annotation syntax.

Added a link to the data visualization curriculum.